### PR TITLE
Fixed typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ install using vim-plug:
 
 [source,vim]
 ----
-Plug 'shwnchpl/vim-scpicker'
+Plug 'shwnchpl/vim-cspicker'
 ----
 
 


### PR DESCRIPTION
Fixes typo in the vim-plug install example in README.adoc.